### PR TITLE
Fix: should return context before change menu options when in gamepad session

### DIFF
--- a/src/lua/client/tweaks/ISUI/TweakWorldObjectContextMenu.lua
+++ b/src/lua/client/tweaks/ISUI/TweakWorldObjectContextMenu.lua
@@ -16,6 +16,8 @@ TweakWorldObjectContextMenu = {
 TweakWorldObjectContextMenu.createMenu = function(player, worldobjects, x, y, test)
     local context = TweakWorldObjectContextMenu.Original.createMenu(player, worldobjects, x, y, test)
 
+    if JoypadState.players[player+1] then return context end
+
     if not SandboxVars.ServerTweaker then return context end
 
     if SandboxVars.ServerTweaker.DisableTradeWithPlayers then


### PR DESCRIPTION
# Proposal

This PR aims to fix options from context menu whe in a gamepad session.

# Issue reference

#3 

# Tasks to be reached

- [x] check if is gamepad session and return context menu without changes.